### PR TITLE
ci: add security code scanning (CodeQL, Semgrep, clj-holmes, OSV-Scanner, clj-watson)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,15 @@
+# Shared CodeQL configuration for Logseq.
+# Referenced by .github/workflows/codeql.yml through the `config-file` input.
+name: "Logseq CodeQL config"
+
+# Add the broader security suite on top of CodeQL's default queries.
+# `security-extended` widens security coverage while avoiding the
+# maintainability/style findings that `security-and-quality` adds.
+queries:
+  - uses: security-extended
+
+# Vendored, minified third-party bundles checked into the tree. These are not
+# reviewable source and only produce noise. node_modules/, static/** and
+# /public are untracked (gitignored) or auto-excluded, so they are not listed.
+paths-ignore:
+  - "**/*.min.js"

--- a/.github/semgrep/logseq-rules.yml
+++ b/.github/semgrep/logseq-rules.yml
@@ -1,0 +1,98 @@
+# Custom Semgrep rules for the languages CodeQL cannot analyze:
+# Clojure / ClojureScript (language id: clojure) and OCaml (language id: ocaml).
+#
+# These are SYNTACTIC pattern matches (Semgrep treats both languages as
+# "experimental"), not source-to-sink taint analysis. They flag dangerous
+# sinks for human review; they do not prove the input is attacker-controlled.
+# Tune severity / add `pattern-not` exceptions as false positives surface.
+
+rules:
+  # ---- Clojure / ClojureScript -----------------------------------------
+
+  - id: logseq-clj-dynamic-eval
+    languages: [clojure]
+    severity: WARNING
+    message: >
+      Dynamic code evaluation (eval / load-string / read-string). If the
+      argument can be influenced by user input this is remote code execution.
+      For parsing untrusted data use clojure.edn/read-string instead.
+    metadata:
+      category: security
+      cwe: "CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code"
+    patterns:
+      - pattern-either:
+          - pattern: (eval $X)
+          - pattern: (load-string $X)
+          - pattern: (read-string $X)
+          - pattern: (clojure.core/read-string $X)
+
+  - id: logseq-clj-shell-exec
+    languages: [clojure]
+    severity: WARNING
+    message: >
+      Shell / process execution. Ensure the command and arguments are not
+      built from untrusted input (command injection).
+    metadata:
+      category: security
+      cwe: "CWE-78: OS Command Injection"
+    patterns:
+      - pattern-either:
+          - pattern: (clojure.java.shell/sh ...)
+          - pattern: (sh/sh ...)
+          - pattern: (.exec (Runtime/getRuntime) ...)
+
+  - id: logseq-cljs-js-eval
+    languages: [clojure]
+    severity: WARNING
+    message: >
+      js/eval executes arbitrary JavaScript in the renderer/main process.
+      Avoid evaluating strings; this is a common XSS / RCE sink.
+    metadata:
+      category: security
+      cwe: "CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code"
+    pattern: (js/eval $X)
+
+  - id: logseq-cljs-inner-html
+    languages: [clojure]
+    severity: WARNING
+    message: >
+      Assigning innerHTML can introduce DOM-based XSS. Prefer text nodes or a
+      sanitizer (e.g. dompurify) for untrusted markup.
+    metadata:
+      category: security
+      cwe: "CWE-79: Cross-site Scripting"
+    pattern: (set! (.-innerHTML $EL) $X)
+
+  # ---- OCaml (cli/) -----------------------------------------------------
+
+  - id: logseq-ocaml-unsafe-deserialization
+    languages: [ocaml]
+    severity: WARNING
+    message: >
+      Marshal.from_* deserializes data without validation. Deserializing
+      untrusted bytes is unsafe (can corrupt memory or be abused for RCE).
+    metadata:
+      category: security
+      cwe: "CWE-502: Deserialization of Untrusted Data"
+    patterns:
+      - pattern-either:
+          - pattern: Marshal.from_string $S $O
+          - pattern: Marshal.from_bytes $B $O
+          - pattern: Marshal.from_channel $C
+
+  - id: logseq-ocaml-command-exec
+    languages: [ocaml]
+    severity: WARNING
+    message: >
+      Executing a shell command / subprocess. Ensure the argument is not
+      attacker-controlled (command injection).
+    metadata:
+      category: security
+      cwe: "CWE-78: OS Command Injection"
+    patterns:
+      - pattern-either:
+          - pattern: Sys.command $CMD
+          - pattern: Unix.system $CMD
+          - pattern: Unix.open_process $CMD
+          - pattern: Unix.open_process_in $CMD
+          - pattern: Unix.open_process_out $CMD

--- a/.github/semgrep/logseq-rules.yml
+++ b/.github/semgrep/logseq-rules.yml
@@ -11,11 +11,12 @@ rules:
 
   - id: logseq-clj-dynamic-eval
     languages: [clojure]
-    severity: WARNING
+    severity: ERROR
     message: >
-      Dynamic code evaluation (eval / load-string / read-string). If the
-      argument can be influenced by user input this is remote code execution.
-      For parsing untrusted data use clojure.edn/read-string instead.
+      Dynamic code evaluation (eval / load-string / read-string, including the
+      cljs.reader and tools.reader aliases). If the argument can be influenced
+      by user input this is remote code execution. For parsing untrusted data
+      use clojure.edn/read-string instead.
     metadata:
       category: security
       cwe: "CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code"
@@ -23,15 +24,23 @@ rules:
       - pattern-either:
           - pattern: (eval $X)
           - pattern: (load-string $X)
+          # read-string is unsafe through clojure.core and the cljs.reader /
+          # tools.reader aliases (honors *read-eval* / tagged literals). The
+          # safe clojure.edn/read-string is intentionally NOT matched.
           - pattern: (read-string $X)
           - pattern: (clojure.core/read-string $X)
+          - pattern: (cljs.reader/read-string $X)
+          - pattern: (reader/read-string $X)
+          - pattern: (cljs.tools.reader/read-string $X)
+          - pattern: (clojure.tools.reader/read-string $X)
 
   - id: logseq-clj-shell-exec
     languages: [clojure]
     severity: WARNING
     message: >
-      Shell / process execution. Ensure the command and arguments are not
-      built from untrusted input (command injection).
+      Shell / process execution (clojure.java.shell, a bare sh refer, or
+      babashka.process shell/process). Ensure the command and arguments are
+      not built from untrusted input (command injection).
     metadata:
       category: security
       cwe: "CWE-78: OS Command Injection"
@@ -39,11 +48,17 @@ rules:
       - pattern-either:
           - pattern: (clojure.java.shell/sh ...)
           - pattern: (sh/sh ...)
+          - pattern: (sh ...)
           - pattern: (.exec (Runtime/getRuntime) ...)
+          # babashka.process (dev/build scripts): bare :refer and qualified.
+          - pattern: (shell ...)
+          - pattern: (process ...)
+          - pattern: (babashka.process/shell ...)
+          - pattern: (babashka.process/process ...)
 
   - id: logseq-cljs-js-eval
     languages: [clojure]
-    severity: WARNING
+    severity: ERROR
     message: >
       js/eval executes arbitrary JavaScript in the renderer/main process.
       Avoid evaluating strings; this is a common XSS / RCE sink.
@@ -56,14 +71,38 @@ rules:
     languages: [clojure]
     severity: WARNING
     message: >
-      Assigning innerHTML can introduce DOM-based XSS. Prefer text nodes or a
-      sanitizer (e.g. dompurify) for untrusted markup.
+      Assigning innerHTML / set-html! can introduce DOM-based XSS. Prefer text
+      nodes or a sanitizer (e.g. dompurify) for untrusted markup.
     metadata:
       category: security
       cwe: "CWE-79: Cross-site Scripting"
-    pattern: (set! (.-innerHTML $EL) $X)
+    patterns:
+      - pattern-either:
+          - pattern: (set! (.-innerHTML $EL) $X)
+          - pattern: (set-html! $EL $X)
+          - pattern: (dom/set-html! $EL $X)
+          - pattern: (gdom/set-html! $EL $X)
+      # Clearing an element with a constant empty string is not an XSS sink.
+      - pattern-not: (set! (.-innerHTML $EL) "")
+
+  - id: logseq-cljs-react-raw-html
+    languages: [clojure]
+    severity: WARNING
+    message: >
+      React raw-HTML injection: the :__html payload renders unescaped markup.
+      Ensure the value is sanitized (e.g. via security/sanitize-html) before
+      rendering untrusted content.
+    metadata:
+      category: security
+      cwe: "CWE-79: Cross-site Scripting"
+    # The Hiccup map-literal form is not reliably matched by the experimental
+    # Clojure parser, so match the React payload key directly.
+    pattern-regex: ":__html"
 
   # ---- OCaml (cli/) -----------------------------------------------------
+  #
+  # These match no call sites in the current tree (cli/ uses none of these
+  # sinks yet); they are forward-looking coverage for future OCaml code.
 
   - id: logseq-ocaml-unsafe-deserialization
     languages: [ocaml]

--- a/.github/workflows/clj-holmes.yml
+++ b/.github/workflows/clj-holmes.yml
@@ -43,7 +43,9 @@ jobs:
           fail-on-result: 'false'
 
       - name: Upload SARIF to code scanning
-        if: always()
+        # Skip when the scan errored without writing a SARIF: uploading a
+        # missing or empty file would fail with a second, misleading error.
+        if: ${{ !cancelled() && hashFiles('clj-holmes.sarif') != '' }}
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: clj-holmes.sarif

--- a/.github/workflows/clj-holmes.yml
+++ b/.github/workflows/clj-holmes.yml
@@ -1,0 +1,50 @@
+# clj-holmes: pattern-based SAST for Clojure / ClojureScript.
+#
+# Complements the custom Semgrep ruleset with clj-holmes' prebuilt open-source
+# rules (clj-holmes-rules). Like Semgrep on these languages it is pattern-based,
+# not source-to-sink taint analysis. Results are uploaded as SARIF to the same
+# code-scanning dashboard, under the "clj-holmes" category.
+#
+# The upstream action publishes no release tags, so it is pinned to a commit SHA
+# (supply-chain hygiene for a security workflow).
+
+name: "clj-holmes"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    - cron: '39 14 * * 3'
+
+permissions:
+  contents: read
+  # Upload SARIF to the code-scanning dashboard.
+  security-events: write
+  # Only required for workflows in private repositories.
+  actions: read
+
+jobs:
+  clj-holmes:
+    name: Clojure SAST
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run clj-holmes
+        # No upstream release tags; pinned to clj-holmes-action main @53daa4d (2026-06-19).
+        uses: clj-holmes/clj-holmes-action@53daa4da4ff495cccf791e4ba4222a8317ddae9e
+        with:
+          output-type: sarif
+          output-file: clj-holmes.sarif
+          # Findings are triaged in the Security tab; do not fail the build.
+          fail-on-result: 'false'
+
+      - name: Upload SARIF to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: clj-holmes.sarif
+          category: clj-holmes

--- a/.github/workflows/clj-watson.yml
+++ b/.github/workflows/clj-watson.yml
@@ -1,0 +1,77 @@
+# clj-watson: dependency (SCA) vulnerability scanning for Clojure deps.edn.
+#
+# Covers JVM/Clojure (Maven) coordinates that OSV-Scanner does not parse. Uses
+# the GitHub Advisory database strategy (no NVD API key required) and uploads
+# SARIF to the code-scanning dashboard, under the "clj-watson" category.
+#
+# Runs on changes to any deps.edn (path-filtered), weekly, and on demand.
+# Dependency-tree resolution is slow, so PR-time SCA is left to OSV-Scanner.
+# To use the OWASP/NVD strategy instead, swap `-t github-advisory` for
+# `-t dependency-check` and provide an NVD API key.
+
+name: "clj-watson"
+
+on:
+  push:
+    branches: [ "master" ]
+    paths:
+      - "**/deps.edn"
+      - ".github/workflows/clj-watson.yml"
+  schedule:
+    - cron: '39 14 * * 5'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Upload SARIF to the code-scanning dashboard.
+  security-events: write
+  # Only required for workflows in private repositories.
+  actions: read
+
+# Toolchain versions mirror build-android.yml.
+env:
+  JAVA_VERSION: '21'
+  CLOJURE_VERSION: '1.12.4.1618'
+
+jobs:
+  clj-watson:
+    name: Clojure dependency CVE scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Setup Clojure
+        uses: DeLaGuardo/setup-clojure@13.5
+        with:
+          cli: ${{ env.CLOJURE_VERSION }}
+
+      - name: Scan deps.edn with clj-watson
+        # clj-watson v6.1.0 pinned by git tag + sha. `-o sarif` writes SARIF to
+        # stdout (redirected to a file); `--no-fail-on-result` keeps the build
+        # green so findings are triaged in the Security tab. GITHUB_TOKEN (the
+        # safe env pattern, not untrusted input) authenticates the advisory API.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          clojure \
+            -Sdeps '{:deps {io.github.clj-holmes/clj-watson {:git/tag "v6.1.0" :git/sha "be98e4db74fb8927db4825cc73bbe2606e44e5e3"}}}' \
+            -M -m clj-watson.cli scan \
+            -p deps.edn \
+            -t github-advisory \
+            -o sarif \
+            --no-fail-on-result \
+            > clj-watson.sarif
+
+      - name: Upload SARIF to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: clj-watson.sarif
+          category: clj-watson

--- a/.github/workflows/clj-watson.yml
+++ b/.github/workflows/clj-watson.yml
@@ -2,7 +2,13 @@
 #
 # Covers JVM/Clojure (Maven) coordinates that OSV-Scanner does not parse. Uses
 # the GitHub Advisory database strategy (no NVD API key required) and uploads
-# SARIF to the code-scanning dashboard, under the "clj-watson" category.
+# SARIF to the code-scanning dashboard, under per-manifest "clj-watson:<path>"
+# categories.
+#
+# Every deps.edn in the tree is scanned: clj-watson resolves a single
+# -p deps.edn at a time, and the standalone manifests (deps/publish, clj-e2e,
+# scripts, libs/cljs-sdk) are not reachable from the root via :local/root. A
+# discover job enumerates them and the scan job fans out over a matrix.
 #
 # Runs on changes to any deps.edn (path-filtered), weekly, and on demand.
 # Dependency-tree resolution is slow, so PR-time SCA is left to OSV-Scanner.
@@ -34,9 +40,32 @@ env:
   CLOJURE_VERSION: '1.12.4.1618'
 
 jobs:
-  clj-watson:
-    name: Clojure dependency CVE scan
+  # Enumerate every deps.edn so the scan matrix covers them all, not just the
+  # root manifest.
+  discover:
+    name: Discover deps.edn files
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.find.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build deps.edn matrix
+        id: find
+        run: |
+          files=$(find . -name deps.edn -not -path '*/node_modules/*' \
+            | sed 's|^\./||' | sort | jq -R . | jq -cs .)
+          echo "matrix=${files}" >> "$GITHUB_OUTPUT"
+
+  clj-watson:
+    name: CVE scan
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        deps: ${{ fromJson(needs.discover.outputs.matrix) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -54,12 +83,18 @@ jobs:
 
       - name: Scan deps.edn with clj-watson
         # clj-watson v6.1.0 pinned by git tag + sha. `-o sarif` writes SARIF to
-        # stdout (redirected to a file); `--no-fail-on-result` keeps the build
-        # green so findings are triaged in the Security tab. GITHUB_TOKEN (the
-        # safe env pattern, not untrusted input) authenticates the advisory API.
+        # stdout; `--no-fail-on-result` keeps the build green so findings are
+        # triaged in the Security tab. GITHUB_TOKEN (the safe env pattern, not
+        # untrusted input) authenticates the advisory API. cd into the manifest's
+        # directory so :local/root paths resolve per project; DEPS_EDN is a
+        # matrix value passed via env, never interpolated into the shell.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPS_EDN: ${{ matrix.deps }}
         run: |
+          cd "$(dirname "$DEPS_EDN")" || exit 1
+          raw="${GITHUB_WORKSPACE}/clj-watson.raw.json"
+          out="${GITHUB_WORKSPACE}/clj-watson.sarif"
           clojure \
             -Sdeps '{:deps {io.github.clj-holmes/clj-watson {:git/tag "v6.1.0" :git/sha "be98e4db74fb8927db4825cc73bbe2606e44e5e3"}}}' \
             -M -m clj-watson.cli scan \
@@ -67,11 +102,18 @@ jobs:
             -t github-advisory \
             -o sarif \
             --no-fail-on-result \
-            > clj-watson.sarif
+            > "$raw"
+          # clj-watson appends a human summary ("Dependencies scanned: N" ...) to
+          # stdout after the SARIF JSON, which makes the raw file invalid SARIF.
+          # Extract only the leading JSON object so the upload gets clean SARIF;
+          # this also fails the step if clj-watson wrote a non-JSON error instead.
+          python3 -c 'import json,sys; data=open(sys.argv[1]).read().lstrip(); obj=json.JSONDecoder().raw_decode(data)[0]; json.dump(obj, open(sys.argv[2],"w"))' "$raw" "$out"
 
       - name: Upload SARIF to code scanning
-        if: always()
+        # Skip when the scan errored without writing a SARIF: uploading a
+        # missing or empty file would fail with a second, misleading error.
+        if: ${{ !cancelled() && hashFiles('clj-watson.sarif') != '' }}
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: clj-watson.sarif
-          category: clj-watson
+          category: clj-watson:${{ matrix.deps }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,150 @@
+# CodeQL "advanced" code scanning, tailored to this repository.
+#
+# Language scope notes (important):
+#   * Logseq's core is ClojureScript/Clojure (~900 files) and the CLI is OCaml
+#     (~120 files). CodeQL has NO analyzer for either, so the bulk of the
+#     codebase is out of scope for code scanning. CodeQL only covers the
+#     languages listed in the matrix below.
+#   * Reliable, no-build, high-value targets are enabled by default:
+#       - actions                GitHub Actions workflows (release pipelines, secrets handling)
+#       - javascript-typescript  packages/ui, libs SDK, deps/db-sync worker, capacitor.config.ts
+#       - python                 sidecar/embedding_server.py and the cli-e2e scripts/tests
+#   * Native mobile targets are opt-in (commented out in the matrix):
+#       - java-kotlin            android/ native plugins  (Kotlin/Java)
+#       - swift                  ios/App native plugins    (Swift/Obj-C)
+#     They require the full Capacitor mobile build (pnpm release-mobile +
+#     `cap sync`) before CodeQL can observe compilation, and swift needs a
+#     macOS runner. The gated setup steps further down prepare those builds;
+#     uncomment the matrix entry to enable. See build-android.yml /
+#     build-ios-release.yml for the canonical pipeline these mirror.
+#
+# Dropped from the GitHub default template:
+#   * c-cpp  - only a single OCaml<->JS FFI stub (cli/lib/js_bytecode_stubs.c);
+#              not worth standing up a compiled-language build.
+#   * ruby   - no first-party Ruby source (auto-detected from the iOS Podfile).
+
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    - cron: '39 14 * * 1'
+
+# Versions mirror build-android.yml so the opt-in native builds match CI.
+env:
+  NODE_VERSION: '24'
+  JAVA_VERSION: '21'
+  PNPM_VERSION: '10.33.0'
+  CLOJURE_VERSION: '1.12.4.1618'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+      # required to fetch internal or private CodeQL packs
+      packages: read
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: actions
+          build-mode: none
+        - language: javascript-typescript
+          build-mode: none
+        - language: python
+          build-mode: none
+        # ---- Native mobile: opt-in (require the full Capacitor build) -------
+        # Uncomment to scan the Android native plugins (Kotlin/Java). Needs
+        # JDK 21 + Android SDK + `pnpm release-mobile` + `cap sync` (the gated
+        # "native setup" steps below provide these; mirrors build-android.yml).
+        # If autobuild cannot locate the Gradle project (it lives under
+        # android/), switch build-mode to `manual` and run `./gradlew` there.
+        # - language: java-kotlin
+        #   build-mode: autobuild
+        #
+        # Uncomment to scan the iOS native plugins (Swift/Obj-C). Runs on
+        # macos-latest and needs CocoaPods + the mobile build.
+        # - language: swift
+        #   build-mode: autobuild
+        #
+        # CodeQL 'language' keywords: 'actions', 'c-cpp', 'csharp', 'go',
+        # 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'.
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # ---- Native-mobile setup (opt-in languages only) ----------------------
+    # Every step here is gated on java-kotlin / swift, so it is skipped for the
+    # default JS / Python / actions scans and costs them nothing. These steps
+    # build the web bundle and sync Capacitor BEFORE `init`, because that work
+    # contains no Kotlin/Swift compilation to trace; CodeQL traces only the
+    # autobuild that runs between `init` and `analyze`.
+
+    - name: Install Node.js
+      if: matrix.language == 'java-kotlin' || matrix.language == 'swift'
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+
+    - name: Set up pnpm
+      if: matrix.language == 'java-kotlin' || matrix.language == 'swift'
+      uses: pnpm/action-setup@v4
+      with:
+        version: ${{ env.PNPM_VERSION }}
+
+    - name: Setup Java JDK
+      if: matrix.language == 'java-kotlin' || matrix.language == 'swift'
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'zulu'
+        java-version: ${{ env.JAVA_VERSION }}
+
+    - name: Setup Clojure
+      if: matrix.language == 'java-kotlin' || matrix.language == 'swift'
+      uses: DeLaGuardo/setup-clojure@13.5
+      with:
+        cli: ${{ env.CLOJURE_VERSION }}
+
+    - name: Build mobile web bundle (CLJS) and sync Capacitor
+      if: matrix.language == 'java-kotlin' || matrix.language == 'swift'
+      env:
+        # Controlled matrix value (not untrusted input); kept in env so the
+        # run block contains no ${{ }} interpolation.
+        CAP_PLATFORM: ${{ (matrix.language == 'swift' && 'ios') || 'android' }}
+      run: |
+        pnpm install --frozen-lockfile
+        pnpm release-mobile
+        pnpm exec cap sync "$CAP_PLATFORM"
+
+    - name: Setup Android SDK
+      if: matrix.language == 'java-kotlin'
+      uses: android-actions/setup-android@v3.2.2
+
+    - name: Install CocoaPods (iOS)
+      if: matrix.language == 'swift'
+      run: pod install --project-directory=ios/App
+
+    # ---- CodeQL -----------------------------------------------------------
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        config-file: ./.github/codeql/codeql-config.yml
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{ matrix.language }}"

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,9 +1,9 @@
 # OSV-Scanner: dependency (SCA) scanning via lockfiles.
 #
-# Covers the npm ecosystem (the five pnpm-lock.yaml files: root, packages/ui,
-# resources, scripts, cli) and any other OSV-supported manifest in the tree.
-# Clojure deps.edn is NOT an OSV-supported lockfile, so JVM/Clojure dependencies
-# are handled separately by clj-watson.yml.
+# Scans every OSV-supported manifest in the tree via `--recursive`, which here is
+# the npm ecosystem (all pnpm-lock.yaml files). Clojure deps.edn is NOT an
+# OSV-supported lockfile, so JVM/Clojure dependencies are handled separately by
+# clj-watson.yml.
 #
 # The OSV reusable workflows are NOT used: they export the full results JSON as a
 # job output, which exceeds the Actions output size limit on this repo (~191
@@ -48,9 +48,11 @@ jobs:
           chmod +x osv-scanner
 
       - name: Scan lockfiles
-        # osv-scanner exits 1 when vulnerabilities are found (expected; findings
-        # are triaged in the Security tab) and >1 on a real error. Tolerate 1,
-        # surface anything worse. SARIF is written regardless of the exit code.
+        # osv-scanner exits 0 (no vulnerabilities) or 1 (vulnerabilities found,
+        # expected: findings are triaged in the Security tab). Tolerate 0 and 1;
+        # any higher code is a real error (e.g. 127 general error, 128 "no
+        # packages found") and fails the job. SARIF is written on exit 0 and 1;
+        # on a hard error it may be absent, so the upload step is gated on it.
         run: |
           ./osv-scanner scan --recursive --format=sarif --output=osv.sarif ./ || code=$?
           if [ "${code:-0}" -gt 1 ]; then
@@ -59,7 +61,9 @@ jobs:
           fi
 
       - name: Upload SARIF to code scanning
-        if: always()
+        # Skip when the scan errored without writing a SARIF: uploading a
+        # missing or empty file would fail with a second, misleading error.
+        if: ${{ !cancelled() && hashFiles('osv.sarif') != '' }}
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: osv.sarif

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,66 @@
+# OSV-Scanner: dependency (SCA) scanning via lockfiles.
+#
+# Covers the npm ecosystem (the five pnpm-lock.yaml files: root, packages/ui,
+# resources, scripts, cli) and any other OSV-supported manifest in the tree.
+# Clojure deps.edn is NOT an OSV-supported lockfile, so JVM/Clojure dependencies
+# are handled separately by clj-watson.yml.
+#
+# The OSV reusable workflows are NOT used: they export the full results JSON as a
+# job output, which exceeds the Actions output size limit on this repo (~191
+# findings across 1100+ packages -> "Maximum object size exceeded"). Running the
+# pinned CLI and uploading SARIF directly avoids that and keeps full control.
+
+name: "OSV-Scanner"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    - cron: '39 14 * * 4'
+
+permissions:
+  contents: read
+  # Upload SARIF to the code-scanning dashboard.
+  security-events: write
+  # Only required for workflows in private repositories.
+  actions: read
+
+env:
+  OSV_SCANNER_VERSION: '2.3.8'
+  # sha256 of osv-scanner_linux_amd64 from the v2.3.8 release SHA256SUMS.
+  OSV_SCANNER_SHA256: 'bc98e15319ed0d515e3f9235287ba53cdc5535d576d24fd573978ecfe9ab92dc'
+
+jobs:
+  osv-scan:
+    name: Dependency scan (lockfiles)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install osv-scanner (pinned, checksum verified)
+        run: |
+          url="https://github.com/google/osv-scanner/releases/download/v${OSV_SCANNER_VERSION}/osv-scanner_linux_amd64"
+          curl -sSfL "$url" -o osv-scanner
+          echo "${OSV_SCANNER_SHA256}  osv-scanner" | sha256sum -c -
+          chmod +x osv-scanner
+
+      - name: Scan lockfiles
+        # osv-scanner exits 1 when vulnerabilities are found (expected; findings
+        # are triaged in the Security tab) and >1 on a real error. Tolerate 1,
+        # surface anything worse. SARIF is written regardless of the exit code.
+        run: |
+          ./osv-scanner scan --recursive --format=sarif --output=osv.sarif ./ || code=$?
+          if [ "${code:-0}" -gt 1 ]; then
+            echo "osv-scanner failed with exit code ${code}"
+            exit "${code}"
+          fi
+
+      - name: Upload SARIF to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: osv.sarif
+          category: osv-scanner

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -33,9 +33,11 @@ jobs:
   semgrep:
     name: Scan (clojure, ocaml)
     runs-on: ubuntu-latest
-    # Official Semgrep image ships the CLI and language analyzers.
+    # Official Semgrep image ships the CLI and language analyzers. Pinned to a
+    # release tag (not :latest) so scans are reproducible and the image cannot
+    # change underneath the workflow.
     container:
-      image: semgrep/semgrep
+      image: semgrep/semgrep:1.167.0
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -52,7 +54,9 @@ jobs:
           .
 
       - name: Upload SARIF to code scanning
-        if: always()
+        # Skip when the scan errored without writing a SARIF: uploading a
+        # missing or empty file would fail with a second, misleading error.
+        if: ${{ !cancelled() && hashFiles('semgrep.sarif') != '' }}
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: semgrep.sarif

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,59 @@
+# Semgrep code scanning, covering the languages CodeQL cannot analyze.
+#
+# CodeQL has no analyzer for Clojure/ClojureScript (~900 files, the core app)
+# or OCaml (~120 files, cli/). Semgrep treats both as "experimental" (syntactic
+# pattern matching, not source-to-sink taint analysis), but it parses them and
+# can flag dangerous sinks for review. Results are uploaded as SARIF and appear
+# in the same GitHub code-scanning UI as CodeQL, under the "semgrep" category.
+#
+# This runs ONLY the repo-local ruleset in .github/semgrep/logseq-rules.yml, so
+# it is self-contained and needs no Semgrep Registry / login / network. To widen
+# coverage, add more `--config` flags (e.g. `--config p/secrets`, `--config auto`)
+# in the scan step below.
+
+name: "Semgrep"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    # Offset one day from the CodeQL schedule.
+    - cron: '39 14 * * 2'
+
+permissions:
+  contents: read
+  # Upload SARIF to the code-scanning dashboard.
+  security-events: write
+  # Only required for workflows in private repositories.
+  actions: read
+
+jobs:
+  semgrep:
+    name: Scan (clojure, ocaml)
+    runs-on: ubuntu-latest
+    # Official Semgrep image ships the CLI and language analyzers.
+    container:
+      image: semgrep/semgrep
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Semgrep scan (SARIF)
+        # No `--error`, so findings do not fail the build; they are triaged in
+        # the Security tab. The step still fails on a real scanner error.
+        run: >
+          semgrep scan
+          --config .github/semgrep/logseq-rules.yml
+          --metrics off
+          --disable-version-check
+          --sarif --output semgrep.sarif
+          .
+
+      - name: Upload SARIF to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep


### PR DESCRIPTION
## Summary

Adds layered security scanning that covers every language CodeQL can reach in this repo, plus the Clojure/ClojureScript/OCaml core it cannot. Every tool emits SARIF into the GitHub code-scanning dashboard (one Security tab, distinct categories).

## Why

CodeQL has no analyzer for Clojure/ClojureScript (~900 files, the core app) or OCaml (`cli/`, ~120 files). A CodeQL-only setup leaves the bulk of Logseq unscanned. No tool offers CodeQL-grade source-to-sink taint analysis for those languages, so the realistic coverage there is pattern-based SAST plus dependency (SCA) scanning.

## What

| Workflow | Tool | Scope | SARIF category |
|---|---|---|---|
| `codeql.yml` | CodeQL | `actions`, `javascript-typescript`, `python` (+ `java-kotlin`/`swift` opt-in) | `/language:*` |
| `semgrep.yml` | Semgrep | Clojure/CLJS, OCaml (repo-local rules) | `semgrep` |
| `clj-holmes.yml` | clj-holmes | Clojure/CLJS (prebuilt rules) | `clj-holmes` |
| `osv-scanner.yml` | OSV-Scanner | all `pnpm-lock.yaml` files (recursive) + other OSV lockfiles | `osv-scanner` |
| `clj-watson.yml` | clj-watson | every Clojure `deps.edn` (Maven coordinates) | `clj-watson:<path>` |

### Coverage map
- JS/TS, Python, Actions: CodeQL (best taint engine for these).
- Clojure/CLJS, OCaml: Semgrep custom rules + clj-holmes (pattern-based; Semgrep "experimental" tier for both).
- Dependencies: npm/lockfiles via OSV-Scanner; Clojure/Maven via clj-watson (every `deps.edn`).

### Decisions
- Dropped `c-cpp` (only `cli/lib/js_bytecode_stubs.c`) and `ruby` (no first-party source) from the GitHub default template.
- CodeQL native mobile (Android `java-kotlin`, iOS `swift`) is opt-in: it requires the full Capacitor build (`pnpm release-mobile` + `cap sync`), and swift needs a macOS runner. Gated setup steps mirroring `build-android.yml` are included; uncomment the matrix entries to enable.
- `security-extended` query suite enabled; vendored `*.min.js` ignored.
- Third-party code pinned: `semgrep/semgrep:1.167.0` (container image), `clj-holmes-action@53daa4d` (no release tags upstream), `osv-scanner` CLI `v2.3.8` (download checksum verified), clj-watson git tag + sha `v6.1.0`.
- OSV-Scanner runs the pinned CLI directly rather than the official reusable workflows: those export the full results JSON as an Actions job output, which exceeds the size limit on this repo (~191 findings across 1100+ packages produced `Maximum object size exceeded`). The CLI writes SARIF directly.
- Scans report to the Security tab without failing `master`; OSV PR runs gate on newly introduced vulnerabilities.

### Limitations
- Semgrep and clj-holmes are syntactic pattern matchers, not taint analysis.
- OSV-Scanner does not parse `deps.edn` (clj-watson covers it) and needs a `gradle.lockfile` to scan Android Gradle deps (none committed).
- Code-scanning upload requires the repository to be public or have GitHub Advanced Security enabled.

## Validation
- `actionlint`: all 5 workflows clean (includes shellcheck on `run:` blocks).
- Semgrep: `--validate` (7 rules, 0 errors); real scan of `src/ cli/ deps/` (786 files, ~100% parsed), 70 findings, valid SARIF.
- YAML parse verified with `yq`.

First runs execute after merge and will surface any runtime tuning (for example clj-watson dependency-resolution time, or clj-holmes SARIF specifics).

## Review follow-ups

Post-review hardening (5 commits on top of the original set):

- **Semgrep rules** now match the idioms the code actually uses: the `cljs.reader` / `reader` / `tools.reader` `read-string` aliases, bare `(sh ...)` and babashka `(shell ...)`/`(process ...)`, `dom/set-html!`, and the React `:__html` payload key. The eval / `js/eval` code-execution rules are now `ERROR`. The repo scan reports 70 findings (was 5), including the previously-missed plugin-API `read-string` (`src/main/logseq/api/db.cljs`) and the unsanitized raw-HTML sinks.
- **Semgrep container** pinned to `semgrep/semgrep:1.167.0` (was unpinned `:latest`), so "third-party code pinned" holds for every tool.
- **clj-watson** scans every `deps.edn` (matrix over all 12 manifests), not just the root: `deps/publish`, `clj-e2e`, `scripts`, and `libs/cljs-sdk` are not reachable from the root via `:local/root` and were previously unscanned despite the `**/deps.edn` trigger.
- **clj-watson SARIF** is sanitized before upload: `clj-watson -o sarif` appends a human summary to stdout after the JSON, which made the redirected file invalid SARIF; the workflow now extracts the leading JSON object (and fails the step on a non-JSON error).
- **SARIF uploads** (semgrep, clj-watson, osv-scanner, clj-holmes) are gated on a non-empty SARIF (`hashFiles(...) != ''`), so a scan error no longer produces a second, misleading "Invalid SARIF" upload failure. The osv-scanner exit-code comments were corrected (128 "no packages found" stays fatal).

Validated: `actionlint` clean on all workflows; `semgrep --validate` (7 rules) plus a real scan confirming the new matches; one live `clj-watson` run confirming the SARIF-extraction fix.
